### PR TITLE
fix_xdg: search only files

### DIFF
--- a/fix_xdg
+++ b/fix_xdg
@@ -12,7 +12,7 @@ if [ ! -d "$RPM_BUILD_ROOT" ]; then
 fi
 
 # Find .desktop files
-find "$RPM_BUILD_ROOT" -name "*.desktop" -a ! -type d -print | while read f; do
+find "$RPM_BUILD_ROOT" -name "*.desktop" -type f -print | while read f; do
 	# Add trailing semicolons to lines starting with 'Actions=' or 'MimeType='
 	# if these lines do not end with '='
 	sed -i 's/^\(Actions=.*\|MimeType=.*\|OnlyShowIn=.*\|Categories=.*\)\([[:alnum:]]\)[[:space:]]*$/\1\2;/' "$f"


### PR DESCRIPTION
Because we don't need to apply `sed -i` on symlinks.