### PR TITLE
fix_xdg: ensure write permissions before modifying .desktop files

### DIFF
--- a/fix_xdg
+++ b/fix_xdg
@@ -13,6 +13,9 @@ fi
 
 # Find .desktop files
 find "$RPM_BUILD_ROOT" -name "*.desktop" -type f -print | while read f; do
+	# Ensure we have write permissions
+	[ -w "$f" ] || chmod u+w "$f" 2>/dev/null || continue
+
 	# Add trailing semicolons to lines starting with 'Actions=' or 'MimeType='
 	# if these lines do not end with '='
 	sed -i 's/^\(Actions=.*\|MimeType=.*\|OnlyShowIn=.*\|Categories=.*\)\([[:alnum:]]\)[[:space:]]*$/\1\2;/' "$f"


### PR DESCRIPTION
Add a check to verify that each .desktop file is writable before attempting to modify it with sed. If the file is not writable, try to set the user-writeable bit (u+w). If this fails, skip the file instead of aborting the entire script.

This prevents build failures when input files are read-only, improving robustness in RPM build environments.